### PR TITLE
Added live example

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: Dockerfile
+tasks:
+- before: >
+    cd test
+  command: >
+    python unet.py &&
+    pdflatex unet.tex &&
+    rm *.aux *.log *.tex &&
+    sleep 12 &&
+    gp open unet.pdf &&
+    cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM gitpod/workspace-full
+
+USER root
+# add your tools here
+RUN apt-get install -yq \
+        texlive-latex-base \
+        texlive-fonts-recommended \
+        texlive-fonts-extra \
+        texlive-latex-extra \
+        evince-common

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Latex code for drawing neural networks for reports and presentation. Have a look
 
 ## Usage
 
+You can try it in Gitpod, a free online dev evironment for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/HarisIqbal88/PlotNeuralNet/blob/master/test/unet.py)
+
     mkdir my_project
     cd my_project
     vim my_arch.py


### PR DESCRIPTION
This PR adds configuration to run and code on plot neural net in Gitpod, a free dev environment for GitHub we have been working on. The goal is to make contributions super easy by providing a single click to code experience. You can open gitpod workspaces on any github repository by prefixig the github URL with 'gitpod.io#/'. Depending on the URL it does the right thing. For instance, prefixing a pull request like this one will open it in code review mode.

For your project I added a docker with the needed dependencies and made the start script so that it runs `test/unet.py` and opens the resulting pdf. Also the python editor is opened so that people can play around with it.

I hope you find it useful, let me know we you have any questions.

<img width="1424" alt="screenshot 2019-02-21 at 06 46 52" src="https://user-images.githubusercontent.com/372735/53146450-7f68e400-35a4-11e9-88bb-ed40b529000a.png">
