### PR TITLE
Added option to name input image node

### DIFF
--- a/pycore/tikzeng.py
+++ b/pycore/tikzeng.py
@@ -34,9 +34,9 @@ def to_begin():
 
 # layers definition
 
-def to_input( pathfile, to='(-3,0,0)', width=8, height=8 ):
+def to_input( pathfile, to='(-3,0,0)', width=8, height=8, name="temp" ):
     return r"""
-\node[canvas is zy plane at x=0] (temp) at """+ to +""" {\includegraphics[width="""+ str(width)+"cm"+""",height="""+ str(height)+"cm"+"""]{"""+ pathfile +"""}};
+\node[canvas is zy plane at x=0] (""" + name + """) at """+ to +""" {\includegraphics[width="""+ str(width)+"cm"+""",height="""+ str(height)+"cm"+"""]{"""+ pathfile +"""}};
 """
 
 # Conv


### PR DESCRIPTION
Adding a `name` parameter to `to_input` allows referencing the input image, e.g., for drawing connectors or relative positioning. I dislike 'temp' as the default name but didn't change it in order to preserve backward compatibility.