### PR TITLE
fix the subimport path error on windows #19

### DIFF
--- a/pycore/tikzeng.py
+++ b/pycore/tikzeng.py
@@ -1,8 +1,12 @@
 
 import os
+import sys
 
 def to_head( projectpath ):
     pathlayers = os.path.join( projectpath, 'layers/' )
+    if sys.platform.startswith('win'):
+        # for windows the latex need '/' in "path/layers"
+        pathlayers = pathlayers.replace('\\', '/')
     return r"""
 \documentclass[border=8pt, multi, tikz]{standalone} 
 \usepackage{import}


### PR DESCRIPTION
Latex need '/' in "path/layers" in windows. So use the `sys.platform` to fix it.


