### PR TITLE
Fix spelling and formatting in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,45 +5,54 @@ Latex code for drawing neural networks for reports and presentation. Have a look
 
 ## TODO
 
-- [X] Python interfaz
+- [X] Python interface
 - [ ] Add easy legend functionality
 - [ ] Add more layer shapes like TruncatedPyramid, 2DSheet etc
 - [ ] Add examples for RNN and likes.
 
-## Latex Usage
-    see examples
-    
-## PyUsage
+## Latex usage
 
-    mkdir my_project
-    cd my_project
+See [`examples`](examples) directory for usage.
+
+## Python usage
+
+First, create a new directory and a new Python file:
+
+    $ mkdir my_project
+    $ cd my_project
     vim my_arch.py
 
-        import sys
-        sys.path.append('../')
-        from pycore.tikzeng import *
+Add the following code to your new file:
 
-        # defined your arch
-        arch = [
-            to_head( '..' ),
-            to_cor(),
-            to_begin(),
-            to_Conv("conv1", 512, 64, offset="(0,0,0)", to="(0,0,0)", height=64, depth=64, width=2 ),
-            to_Pool("pool1", offset="(0,0,0)", to="(conv1-east)"),
-            to_Conv("conv2", 128, 64, offset="(1,0,0)", to="(pool1-east)", height=32, depth=32, width=2 ),
-            to_connection( "pool1", "conv2"),
-            to_Pool("pool2", offset="(0,0,0)", to="(conv2-east)", height=28, depth=28, width=1),
-            to_SoftMax("soft1", 10 ,"(3,0,0)", "(pool1-east)", caption="SOFT"  ),
-            to_connection("pool2", "soft1"),
-            to_end()
-            ]
+```python
+import sys
+sys.path.append('../')
+from pycore.tikzeng import *
 
-        def main():
-            namefile = str(sys.argv[0]).split('.')[0]
-            to_generate(arch, namefile + '.tex' )
+# defined your arch
+arch = [
+    to_head( '..' ),
+    to_cor(),
+    to_begin(),
+    to_Conv("conv1", 512, 64, offset="(0,0,0)", to="(0,0,0)", height=64, depth=64, width=2 ),
+    to_Pool("pool1", offset="(0,0,0)", to="(conv1-east)"),
+    to_Conv("conv2", 128, 64, offset="(1,0,0)", to="(pool1-east)", height=32, depth=32, width=2 ),
+    to_connection( "pool1", "conv2"),
+    to_Pool("pool2", offset="(0,0,0)", to="(conv2-east)", height=28, depth=28, width=1),
+    to_SoftMax("soft1", 10 ,"(3,0,0)", "(pool1-east)", caption="SOFT"  ),
+    to_connection("pool2", "soft1"),
+    to_end()
+    ]
 
-        if __name__ == '__main__':
-            main()
+def main():
+    namefile = str(sys.argv[0]).split('.')[0]
+    to_generate(arch, namefile + '.tex' )
+
+if __name__ == '__main__':
+    main()
+```
+
+Now, run the program as follows:
 
     bash ../tikzmake.sh my_arch
 


### PR DESCRIPTION
* Add link to `examples` directory
* Convert text to complete sentences for readability
* Separate bash and Python code for better understanding
* Add Python syntax highlighting
* Add explicit instructions to help users get started easier