### PR TITLE
fix xdg-open not found error on MacOS

### DIFF
--- a/tikzmake.sh
+++ b/tikzmake.sh
@@ -7,5 +7,8 @@ pdflatex $1.tex
 rm *.aux *.log *.vscodeLog
 rm *.tex
 
-xdg-open $1.pdf
-
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    open $1.pdf
+else
+    xdg-open $1.pdf
+fi


### PR DESCRIPTION
Hi @HarisIqbal88 , thank you for contributing this work! 

There is a minor change. `xdg-open` does not ship with MacOS by default. To use it, one may need to install additional packages on Mac. However, there is an equivalent command on MacOS, which is `open`. The suggested change will detect the OS and decide the correct file opening command to use. 
