### PR TITLE
Fixing os.path.join '\' issue for Windows compatibility

### DIFF
--- a/pycore/tikzeng.py
+++ b/pycore/tikzeng.py
@@ -2,7 +2,7 @@
 import os
 
 def to_head( projectpath ):
-    pathlayers = os.path.join( projectpath, 'layers/' )
+    pathlayers = os.path.join( projectpath, 'layers/' ).replace('\\', '/')
     return r"""
 \documentclass[border=8pt, multi, tikz]{standalone} 
 \usepackage{import}


### PR DESCRIPTION
Under windows platform the `os.path.join` module use `\` to connect different parts, causing error in pdflatex. This pull request fix the issue by replaceing all `\`s with `/`. 

You can check this by using git bash.

Contributor: [Lotayou](https://github.com/Lotayou)
