### PR TITLE
add sum layer

### DIFF
--- a/pycore/tikzeng.py
+++ b/pycore/tikzeng.py
@@ -20,6 +20,7 @@ def to_cor():
 \def\FcColor{rgb:blue,5;red,2.5;white,5}
 \def\FcReluColor{rgb:blue,5;red,5;white,4}
 \def\SoftmaxColor{rgb:magenta,5;black,7}   
+\def\SumColor{rgb:blue,5;green,15}
 """
 
 def to_begin():
@@ -160,6 +161,19 @@ def to_SoftMax( name, s_filer=10, offset="(0,0,0)", to="(0,0,0)", width=1.5, hei
         height="""+ str(height) +""",
         width="""+ str(width) +""",
         depth="""+ str(depth) +"""
+        }
+    };
+"""
+
+def to_Sum( name, offset="(0,0,0)", to="(0,0,0)", radius=2.5, opacity=0.6):
+    return r"""
+\pic[shift={"""+ offset +"""}] at """+ to +""" 
+    {Ball={
+        name=""" + name +""",
+        fill=\SumColor,
+        opacity="""+ str(opacity) +""",
+        radius="""+ str(radius) +""",
+        logo=$+$
         }
     };
 """

--- a/pyexamples/test_simple.py
+++ b/pyexamples/test_simple.py
@@ -15,6 +15,8 @@ arch = [
     to_Pool("pool2", offset="(0,0,0)", to="(conv2-east)", height=28, depth=28, width=1),
     to_SoftMax("soft1", 10 ,"(3,0,0)", "(pool1-east)", caption="SOFT"  ),
     to_connection("pool2", "soft1"),    
+    to_Sum("sum1", offset="(1.5,0,0)", to="(soft1-east)", radius=2.5, opacity=0.6),
+    to_connection("soft1", "sum1"),
     to_end()
     ]
 


### PR DESCRIPTION
Thank you for sharing the warehouse. It is great!

But I found that the `SUM` Layer in [FCN-8](https://github.com/HarisIqbal88/PlotNeuralNet/tree/master/examples/fcn8s) under the example folder is **NOT** implemented in Python. Concretely, It's not in `pycore/tikzeng.py`.

So I modified the `pyexample/test_simple.py` and added the 'to Sum' function in the right way.
**If the user runs: `bash ../tikzmake.sh test_simple`, it shows:**

![image](https://user-images.githubusercontent.com/46623714/97769204-dd184680-1b63-11eb-999c-9f2521247d4b.png)

Thanks again for your kindness.
