### PR TITLE
Added unet branch connection python function

### DIFF
--- a/pycore/tikzeng.py
+++ b/pycore/tikzeng.py
@@ -184,6 +184,12 @@ def to_connection( of, to):
 \draw [connection]  ("""+of+"""-east)    -- node {\midarrow} ("""+to+"""-west);
 """
 
+def to_unet_branch_connection(of, to, name):
+    return r"""
+\path (""" + of + """-east) -- (""" + to + """-west|-""" + of + """-west) coordinate[pos=0.5] (""" + name + """);
+\draw[connection](""" + of + """-east)--node{\midarrow}(""" + name + """)--node{\midarrow}(""" + to + """-west-|""" + name + """)--node{\midarrow}("""+ to + """-west);
+"""
+
 def to_skip( of, to, pos=1.25):
     return r"""
 \path ("""+ of +"""-southeast) -- ("""+ of +"""-northeast) coordinate[pos="""+ str(pos) +"""] ("""+ of +"""-top) ;


### PR DESCRIPTION
The connection between unet branches are drawn diagonal, if one uses the `to_connection` function.

The `to_unet_branch_connection` allows the python user to draw the beautiful connections shown in the examples directory directly.

Parameters are:
 - of The source of the connection
 - to The target of the connection
 - name A name of the generated point (e.g. connectionX)

Best,
Jan